### PR TITLE
Add Contributors Section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ http-server -p 8000
 - Replace placeholder movie images with local assets for offline demos.
 - Add unit tests for JavaScript behavior if the project grows (use Jest/Playwright for UI tests).
 
+## Contributor
+
+A heartfelt thank you to all the contributors who have dedicated their time and effort to make this project a success.  
+Your contributions—whether it’s code, design, testing, or documentation—are truly appreciated! 🚀
+
+#### Thanks to all the wonderful contributors 💖
+
+<a href="https://github.com/Sam-coder101/Netflix/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Sam-coder101/Netflix" />
+</a>
+
+#### See full list of contribution from contributor [Contributor Graph](https://github.com/Sam-coder101/Netflix/graphs/contributors)
+
 ## License
 
 No license is specified. Add a `LICENSE` file if you want to grant reuse permissions.


### PR DESCRIPTION
Description
This PR adds a Contributors section to the README.md to recognize and showcase all contributors, making the repository more welcoming for new contributors.

Current Problem
The README.md currently lacks a Contributors section to recognize contributors and guide new ones.

Proposed Solution
Add a Contributors section at the end of README.md
Include an auto-generated contributor badge via [contrib.rocks](https://contrib.rocks/)
Update Table of Contents to include this new section
Keep all existing content intact and improve formatting where necessary

Benefits
Recognizes contributors and shows appreciation
Makes the repository more welcoming for new contributors
Improves documentation readability and structure

Close issue #37 