### PR TITLE
Fix: Improve search bar visibility and alignment for dark/light modes

### DIFF
--- a/Netflix/Astyle.css
+++ b/Netflix/Astyle.css
@@ -1107,3 +1107,75 @@ body.light-mode {
   transform: translateY(0);
 }
 
+/* ===== Search bar visibility fix (dark + light mode) ===== */
+.search-container {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex: 0 0 auto;            /* don't grow to fill entire row */
+  margin-left: 12px;
+}
+
+/* Desktop input */
+#movieSearch {
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255,255,255,0.10);
+  background: rgba(255,255,255,0.08);
+  color: #fff;
+  font-size: 15px;
+  width: 200px;
+  transition: width .22s ease, background .18s ease, border-color .18s ease, box-shadow .18s ease;
+  box-shadow: none;
+}
+
+/* placeholder contrast */
+#movieSearch::placeholder {
+  color: rgba(255,255,255,0.65);
+}
+
+/* focus boost so it's easy to spot */
+#movieSearch:focus {
+  outline: none;
+  border-color: #e50914;
+  background: rgba(255,255,255,0.12);
+  width: 260px;
+  box-shadow: 0 6px 18px rgba(229,9,20,0.07);
+}
+
+/* ----- Light mode adjustments ----- */
+body.light-mode #movieSearch {
+  background: rgba(0,0,0,0.06);       /* subtle dark tint on white background */
+  color: #111;
+  border: 1px solid rgba(0,0,0,0.08);
+}
+body.light-mode #movieSearch::placeholder {
+  color: rgba(0,0,0,0.45);
+}
+body.light-mode #movieSearch:focus {
+  background: rgba(0,0,0,0.08);
+  border-color: #c13109; /* matches theme-switch active color */
+  box-shadow: 0 6px 18px rgba(0,0,0,0.06);
+}
+
+/* Responsive: stack below title on small screens */
+@media (max-width: 768px) {
+  .content-top {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+  .search-container {
+    justify-content: flex-start;
+    width: 100%;
+    margin-left: 0;
+  }
+  #movieSearch {
+    width: 100%;
+    max-width: 360px;
+  }
+  #movieSearch:focus {
+    width: 100%;
+    max-width: 420px;
+  }
+}


### PR DESCRIPTION
# 📝 Pull Request

## 📄 Description

This PR improves the **search bar visibility and alignment** in the *Trending Now* section of the Netflix Clone project.

Previously, the search input field blended with the background — especially in **light mode**, making it nearly invisible.
This update ensures the search bar is **clearly visible** in both dark and light themes, stays aligned beside the heading on desktop, and moves below it on smaller screens.

No major layout or CSS structure changes were made — just subtle design improvements for better usability.

## 🖼️ Screenshots (before & after)

**Before:**
🔸 Search bar was barely visible (white on white in light mode).
<img width="1937" height="130" alt="image" src="https://github.com/user-attachments/assets/00092599-18d2-4179-865f-8fdea0bb17cc" />

**After:**
✅ Clear contrast and proper spacing.
✅ Aligned neatly beside “Trending Now” on larger screens.
✅ Responsive — shifts below on smaller viewports.
<img width="524" height="134" alt="image" src="https://github.com/user-attachments/assets/98dfd817-5f26-4b54-b156-d5e635f55438" />

---

## 🧩 Type of Change

* [x] 🐛 Bug Fix
* [x] ⚡ Enhancement / Optimization
* [ ] ✨ New Feature
* [ ] 🧰 Refactoring
* [ ] 🧾 Documentation Update
* [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

* [x] I have performed a self-review of my code.
* [x] I have tested my changes locally and they work as expected.
* [x] My changes do not break any existing functionality.
* [x] I have kept the CSS changes minimal and non-intrusive.
* [x] I have ensured compatibility for both dark and light modes.
* [ ] I have linked all relevant issues (if applicable).

---

## 💬 Additional Notes (Optional)

* Minor CSS additions only (`Astyle.css` at the end).
* Uses theme-aware colors and simple focus effects.
* Please consider marking this PR as **Hacktoberfest-accepted** 